### PR TITLE
Add notebook version of failing chips extraction

### DIFF
--- a/extract_failing_chips_notebook.ipynb
+++ b/extract_failing_chips_notebook.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extract Failing Chips Notebook\n",
+    "This notebook replicates the functionality of `extract_failing_chips.py` and\n",
+    "lets you select two wafer CSVs to compare." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from extract_failing_chips import compare_coverage\n",
+    "import pandas as pd\n",
+    "from IPython.display import display" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "file_a = input('Path to first wafer CSV: ')\n",
+    "file_b = input('Path to second wafer CSV: ')\n",
+    "compare_coverage(file_a, file_b)" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "print('Coverage CSV preview:')\n",
+    "display(pd.read_csv('coverage.csv').head())\n",
+    "print('Summary CSV preview:')\n",
+    "display(pd.read_csv('summary.csv').head())" 
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3", 
+   "language": "python", 
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py", 
+   "mimetype": "text/x-python", 
+   "name": "python", 
+   "nbconvert_exporter": "python", 
+   "pygments_lexer": "ipython3", 
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/extract_failing_chips_notebook.ipynb
+++ b/extract_failing_chips_notebook.ipynb
@@ -2,57 +2,53 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "118bac62",
    "metadata": {},
    "source": [
     "# Extract Failing Chips Notebook\n",
-    "This notebook replicates the functionality of `extract_failing_chips.py` and\n",
-    "lets you select two wafer CSVs to compare." 
+    "This notebook replicates `extract_failing_chips.py` but lets you select CSV files interactively."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "d26b15ec",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from extract_failing_chips import compare_coverage\n",
     "import pandas as pd\n",
-    "from IPython.display import display" 
+    "from IPython.display import display, clear_output\n",
+    "import ipywidgets as widgets"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ba87b30c",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "file_a = input('Path to first wafer CSV: ')\n",
-    "file_b = input('Path to second wafer CSV: ')\n",
-    "compare_coverage(file_a, file_b)" 
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "print('Coverage CSV preview:')\n",
-    "display(pd.read_csv('coverage.csv').head())\n",
-    "print('Summary CSV preview:')\n",
-    "display(pd.read_csv('summary.csv').head())" 
+    "file_a_widget = widgets.Text(description='File A:', placeholder='path/to/wafer_A.csv')\n",
+    "file_b_widget = widgets.Text(description='File B:', placeholder='path/to/wafer_B.csv')\n",
+    "run_button = widgets.Button(description='Run comparison')\n",
+    "output = widgets.Output()\n",
+    "\n",
+    "def on_run_clicked(b):\n",
+    "    with output:\n",
+    "        clear_output()\n",
+    "        compare_coverage(file_a_widget.value, file_b_widget.value)\n",
+    "        print('Coverage CSV preview:')\n",
+    "        display(pd.read_csv('coverage.csv').head())\n",
+    "        print('Summary CSV preview:')\n",
+    "        display(pd.read_csv('summary.csv').head())\n",
+    "\n",
+    "run_button.on_click(on_run_clicked)\n",
+    "display(file_a_widget, file_b_widget, run_button, output)"
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3", 
-   "language": "python", 
-   "name": "python3"
-  },
-  "language_info": {
-   "file_extension": ".py", 
-   "mimetype": "text/x-python", 
-   "name": "python", 
-   "nbconvert_exporter": "python", 
-   "pygments_lexer": "ipython3", 
-   "version": "3.11"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- add a Jupyter Notebook `extract_failing_chips_notebook.ipynb` that wraps the script

## Testing
- `python extract_failing_chips.py --compare wafer_A.csv wafer_B.csv`
- `python -m py_compile extract_failing_chips.py`
- `python - <<'PY'
import nbformat
nbformat.read(open('extract_failing_chips_notebook.ipynb'), as_version=4)
print('Notebook syntax OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68770ace7924832f8dab58512d2da82e